### PR TITLE
Doc fix, return source in source_url

### DIFF
--- a/muck.py
+++ b/muck.py
@@ -146,7 +146,7 @@ def source_url(url, target=None, ext='', expected_status_code=200, headers={},
  timeout=4, delay=0, delayRange=0):
   target = fetch(url, target=target, ext=ext, expected_status_code=expected_status_code,
     headers=headers, timeout=timeout, delay=delay, delayRange=delayRange)
-  source(target)
+  return source(target)
 
 
 # module exports. when imported, muck provides functions that make data dependencies explicit.

--- a/readme.wu
+++ b/readme.wu
@@ -9,7 +9,7 @@ Muck is a build tool; given a target (a file to be built), it looks in the curre
 
 - Install the latest python3 from http://python.org; Muck tracks python3 aggressively.
 - Install the following python dependencies:
-  - `pip3 --upgrade install agate pygal requests beautifulsoup4`
+  - `pip3 install --upgrade agate pygal requests beautifulsoup4`
 - Clone the repository somewhere or add it as a submodule to your project.
 - In the `muck` root directory, run `git submodule update --init --recursive` to get Muck's dependencies.
 


### PR DESCRIPTION
1. Fixes a small documentation error.
2. Changes `source_url()` to return the result of `source()`. Before, calling `source_url()` in a muck project file would return `None`, which made it impossible to interact with scraped pages in the same muck script you scraped from. Unsure if there are unintended side-effects to this change, but seems unlikely given that we're simply returning results.
